### PR TITLE
Implement PassThruReadMsg for Linux

### DIFF
--- a/adapter/passthru/passThru_linux.go
+++ b/adapter/passthru/passThru_linux.go
@@ -133,6 +133,25 @@ func (j *PassThru) PassThruDisconnect(channelID uint32) error {
 	return CheckError(ret)
 }
 
+func (j *PassThru) PassThruReadMsg(channelID uint32, pMsg *PassThruMsg, timeout uint32) (uint32, error) {
+	pNumMsgs := uint32(1)
+	// long PassThruReadMsgs(unsigned long ChannelID, PassThruMsg *pMsg, unsigned long *pNumMsgs, unsigned long Timeout);
+	ret := j.passThruReadMsgs(
+		channelID,
+		pMsg,
+		&pNumMsgs,
+		timeout,
+	)
+	if err := CheckError(ret); err != nil {
+		if str, err2 := j.PassThruGetLastError(); err2 == nil {
+			return 0, fmt.Errorf("%s: %w", str, err)
+		} else {
+			return 0, err
+		}
+	}
+	return pNumMsgs, nil
+}
+
 // PassThruReadMsgs long PassThruReadMsgs(unsigned long ChannelID, PassThruMsg *pMsg, unsigned long *pNumMsgs, unsigned long Timeout);
 func (j *PassThru) PassThruReadMsgs(channelID uint32, pMsg *PassThruMsg, pNumMsgs *uint32, timeout uint32) error {
 	ret := j.passThruReadMsgs(


### PR DESCRIPTION
The module wasn't compiling on Linux because PassThruReadMsg is not implemented for Linux in the source

It's only used by the J2534 code, which isn't compatible with Linux, but its absence makes the whole module unusable on Linux, even though it works with other devices (like SocketCAN)

The code is a simple copy/paste of the Windows code, with the changes that make the Windows and Linux versions of other functions differ