### PR TITLE
Support extended frame identifier on J2534 & SocketCAN + 250kbps baudrate on J2534

### DIFF
--- a/adapter/j2534.go
+++ b/adapter/j2534.go
@@ -98,6 +98,9 @@ func (ma *J2534) Init(ctx context.Context) error {
 	var swcan bool
 	var baudRate uint32
 	switch ma.cfg.CANRate {
+	case 250:
+		baudRate = 250000
+		ma.protocol = passthru.CAN
 	case 33.3:
 		baudRate = 33333
 		ma.protocol = passthru.SW_CAN_PS

--- a/adapter/socketcan_linux.go
+++ b/adapter/socketcan_linux.go
@@ -146,6 +146,7 @@ func (a *SocketCAN) sendManager(ctx context.Context) {
 			return
 		case f := <-a.send:
 			frame := can.Frame{}
+			frame.IsExtended = a.cfg.UseExtendedID
 			frame.ID = f.Identifier()
 			frame.Length = uint8(f.Length())
 			data := can.Data{}

--- a/gocan.go
+++ b/gocan.go
@@ -20,14 +20,15 @@ type Adapter interface {
 }
 
 type AdapterConfig struct {
-	Debug        bool
-	Port         string
-	PortBaudrate int
-	CANRate      float64
-	CANFilter    []uint32
-	PrintVersion bool
-	OnMessage    func(string)
-	OnError      func(error)
+	Debug         bool
+	Port          string
+	PortBaudrate  int
+	CANRate       float64
+	CANFilter     []uint32
+	UseExtendedID bool
+	PrintVersion  bool
+	OnMessage     func(string)
+	OnError       func(error)
 }
 
 type Opts func(*Client)


### PR DESCRIPTION
This PR adds 2 improvements to the module:
- Support 250kbps baudrate on J2534 controller
- Support extended frame identifier on J2534 & SocketCAN: this allows the module to send and receive frames with 29bit identifiers, as opposed to non-extended frames with 11bit identifiers