### PR TITLE
Socketcan driver fix, and j2534 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ Most adapters that comes with a J2534 DLL will work. The list given is just ones
 
 ### Other
 
-* SocketCAN
+* SocketCAN, note. to run from user space set cap_net_admin for target application ```sudo setcap cap_net_admin=eip APPNAME```
 * OBDX Pro GT BLE & Wifi
 * Combiadapter via libusb

--- a/examples/passthru/iso14230_dice_crc_vin.go
+++ b/examples/passthru/iso14230_dice_crc_vin.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+	"github.com/roffe/gocan/pkg/passthru"
+)
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
+}
+
+func main() {
+	if err := asd(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func asd() error {
+	pt, err := passthru.New(`/home/witold/.passthru/libj2534drv.so`)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var deviceID uint32 = 1
+	var channelID uint32 = 1
+	if err := pt.PassThruOpen("", &deviceID); err != nil {
+		return fmt.Errorf("PassThruOpen: %w", err)
+	}
+
+	defer pt.PassThruClose(deviceID)
+
+	if err := pt.PassThruConnect(deviceID, passthru.ISO14230, passthru.ISO9141_K_LINE_ONLY, 10400, &channelID); err != nil {
+		return fmt.Errorf("PassThruConnect: %w", err)
+	}
+	defer pt.PassThruDisconnect(channelID)
+
+	opts := &passthru.SCONFIG_LIST{
+		NumOfParams: 3,
+		Params: []passthru.SCONFIG{
+			{
+				Parameter: passthru.P4_MIN,
+				Value:     0xA,
+			},
+			{
+				Parameter: passthru.TIDLE,
+				Value:     0x1,
+			},
+			{
+				Parameter: passthru.TWUP,
+				Value:     0x32,
+			},
+			{
+				Parameter: passthru.TINIL,
+				Value:     0x19,
+			},
+		},
+	}
+	if err := pt.PassThruIoctl(channelID, passthru.SET_CONFIG, opts); err != nil {
+		return fmt.Errorf("PassThruIoctl set options: %w", err)
+	}
+
+	opts = &passthru.SCONFIG_LIST{
+		NumOfParams: 2,
+		Params: []passthru.SCONFIG{
+			{
+				Parameter: passthru.P3_MIN,
+				Value:     110,
+			},
+			{
+				Parameter: passthru.LOOPBACK,
+				Value:     0,
+			},
+		},
+	}
+	if err := pt.PassThruIoctl(channelID, passthru.SET_CONFIG, opts); err != nil {
+		return fmt.Errorf("PassThruIoctl set options: %w", err)
+	}
+
+	filterID := uint32(0)
+	msg1 := uint32(1)
+	noMsg1 := uint32(1)
+	noMsg2 := uint32(2)
+	rxMSGS := &passthru.PassThruMsg{}
+
+	mask := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   4,
+		Data:       [4128]byte{0x00, 0x00, 0x00, 0x00},
+	}
+
+	pattern := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   4,
+		Data:       [4128]byte{0x00, 0x00, 0x00, 0x00},
+	}
+
+	if err := pt.PassThruStartMsgFilter(channelID, passthru.PASS_FILTER, mask, pattern, nil, &filterID); err != nil {
+		return fmt.Errorf("PassThruStartMsgFilter: %w", err)
+	}
+	//send msg before Fast init, it shall FAIL
+	txMSG2 := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   6,
+		Data: [4128]byte{0x80, 0x41, 0xF1, 0x02, 0x21, 0x24},
+	}
+	log.Println("seng msg before FAST INIT prosedure, it shall fail:");
+	if err := pt.PassThruWriteMsgs(channelID, txMSG2, &msg1, 500); err != nil {
+		log.Println(err);
+	}
+
+	//fast init
+	txMSG := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   4,
+		Data: [4128]byte{0x81, 0x41, 0xF1, 0x81}, // 81 41 F1 81
+	}
+
+	rxMSG := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+	}
+
+	if err := pt.PassThruIoctl(channelID, passthru.FAST_INIT, txMSG, rxMSG); err != nil {
+		return fmt.Errorf("PassThruIoctl fast init: %w", err)
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSG2, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &noMsg2, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSG2, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &noMsg2, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+
+	txMSG3 := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   6,
+		Data: [4128]byte{0x80, 0x41, 0xF1, 0x02, 0x1a, 0x80},
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSG3, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &noMsg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &noMsg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	log.Println("VIN: " + string(rxMSGS.Data[5:22]))
+	log.Println("lets waits 10s, check if adapter tester present is working, if crash then its not, otherwise read VIN again")
+
+	time.Sleep(10 * time.Second)
+	if err := pt.PassThruWriteMsgs(channelID, txMSG3, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &noMsg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &noMsg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	log.Println("VIN: " + string(rxMSGS.Data[5:22]))
+
+	// terminate session
+	txMSG4 := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   5,
+		Data: [4128]byte{0x80, 0x41, 0xF1, 0x01, 0x82},
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSG4, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+
+	return nil
+}

--- a/examples/passthru/iso14230_dice_nocrc_vin.go
+++ b/examples/passthru/iso14230_dice_nocrc_vin.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+	"github.com/roffe/gocan/pkg/passthru"
+)
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
+}
+
+func main() {
+	if err := asd(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func asd() error {
+	pt, err := passthru.New(`/home/witold/.passthru/libj2534drv.so`)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var deviceID uint32 = 1
+	var channelID uint32 = 1
+	if err := pt.PassThruOpen("", &deviceID); err != nil {
+		return fmt.Errorf("PassThruOpen: %w", err)
+	}
+	defer pt.PassThruClose(deviceID)
+
+	if err := pt.PassThruConnect(deviceID, passthru.ISO14230, passthru.ISO9141_NO_CHECKSUM | passthru.ISO9141_K_LINE_ONLY, 10400, &channelID); err != nil {
+		return fmt.Errorf("PassThruConnect: %w", err)
+	}
+	defer pt.PassThruDisconnect(channelID)
+
+	opts := &passthru.SCONFIG_LIST{
+		NumOfParams: 3,
+		Params: []passthru.SCONFIG{
+			{
+				Parameter: passthru.P4_MIN,
+				Value:     0xA,
+			},
+			{
+				Parameter: passthru.TIDLE,
+				Value:     0x1,
+			},
+			{
+				Parameter: passthru.TWUP,
+				Value:     0x32,
+			},
+			{
+				Parameter: passthru.TINIL,
+				Value:     0x19,
+			},
+		},
+	}
+	if err := pt.PassThruIoctl(channelID, passthru.SET_CONFIG, opts); err != nil {
+		return fmt.Errorf("PassThruIoctl set options: %w", err)
+	}
+
+	opts = &passthru.SCONFIG_LIST{
+		NumOfParams: 2,
+		Params: []passthru.SCONFIG{
+			{
+				Parameter: passthru.P3_MIN,
+				Value:     110,
+			},
+			{
+				Parameter: passthru.LOOPBACK,
+				Value:     0,
+			},
+		},
+	}
+	if err := pt.PassThruIoctl(channelID, passthru.SET_CONFIG, opts); err != nil {
+		return fmt.Errorf("PassThruIoctl set options: %w", err)
+	}
+
+	filterID := uint32(0)
+
+	mask := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   4,
+		Data:       [4128]byte{0x00, 0x00, 0x00, 0x00},
+	}
+
+	pattern := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   4,
+		Data:       [4128]byte{0x00, 0x00, 0x00, 0x00},
+	}
+
+	if err := pt.PassThruStartMsgFilter(channelID, passthru.PASS_FILTER, mask, pattern, nil, &filterID); err != nil {
+		return fmt.Errorf("PassThruStartMsgFilter: %w", err)
+	}
+
+	txMSG := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   5,
+		Data: [4128]byte{0x81, 0x41, 0xF1, 0x81, 0x34}, // 81 41 F1 81
+	}
+
+	rxMSG := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+	}
+
+	if err := pt.PassThruIoctl(channelID, passthru.FAST_INIT, txMSG, rxMSG); err != nil {
+		return fmt.Errorf("PassThruIoctl fast init: %w", err)
+	}
+
+	msg1 := uint32(1)
+	noMessages := uint32(2)
+	rxMSGS := &passthru.PassThruMsg{}
+
+	txMSGT := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   6,
+		Data: [4128]byte{0x80, 0x41, 0xF1, 0x01, 0x3E, 0xF1},
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSGT, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+
+	txMSG2 := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   7,
+		Data: [4128]byte{0x80, 0x41, 0xF1, 0x02, 0x21, 0x24, 0xF9},
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSG2, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &noMessages, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+
+	if err := pt.PassThruWriteMsgs(channelID, txMSG2, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &noMessages, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+
+	log.Println("lets waits 10s, check if adapter tester present is working, if crash then its not, otherwise read VIN") 
+	time.Sleep(10 * time.Second)
+	txMSG3 := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   7,
+		Data: [4128]byte{0x80, 0x41, 0xF1, 0x02, 0x1A, 0x80, 0x4E},
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSG3, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	log.Println("VIN: " + string(rxMSGS.Data[5:22]))
+
+	txMSG4 := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO14230,
+		DataSize:   7,
+		Data: [4128]byte{0x80, 0x41, 0xF1, 0x02, 0x1A, 0x80, 0x4A}, //bad checksum
+	}
+	log.Println("Wrong CRC in msg, shall fail: ")
+	if err := pt.PassThruWriteMsgs(channelID, txMSG4, &msg1, 500); err != nil {
+		log.Println(fmt.Errorf("PassThruWriteMsgs: %w", err))
+	}
+
+	return nil
+}

--- a/examples/passthru/iso15765_trionic8_vin.go
+++ b/examples/passthru/iso15765_trionic8_vin.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"github.com/roffe/gocan/pkg/passthru"
+)
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
+}
+
+func main() {
+	if err := asd(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func asd() error {
+	pt, err := passthru.New(`/home/witold/.passthru/libj2534drv.so`)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var deviceID uint32 = 1
+	var channelID uint32 = 1
+	if err := pt.PassThruOpen("", &deviceID); err != nil {
+		return fmt.Errorf("PassThruOpen: %w", err)
+	}
+	defer pt.PassThruClose(deviceID)
+
+	if err := pt.PassThruConnect(deviceID, passthru.ISO15765, 0, 500000, &channelID); err != nil {
+		return fmt.Errorf("PassThruConnect: %w", err)
+	}
+	defer pt.PassThruDisconnect(channelID)
+
+	filterID := uint32(0)
+
+	mask := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO15765,
+		DataSize:   4,
+		Data:       [4128]byte{0xFF, 0xFF, 0xFF, 0xFF},
+	}
+
+	pattern := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO15765,
+		DataSize:   4,
+		Data:       [4128]byte{0x00, 0x00, 0x07, 0xE8},
+	}
+
+	flow := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO15765,
+		DataSize:   4,
+		Data:       [4128]byte{0x00, 0x00, 0x07, 0xE0},
+	}
+
+	if err := pt.PassThruStartMsgFilter(channelID, passthru.FLOW_CONTROL_FILTER, mask, pattern, flow, &filterID); err != nil {
+		return fmt.Errorf("PassThruStartMsgFilter: %w", err)
+	}
+
+	msg1 := uint32(1)
+	rxMSGS := &passthru.PassThruMsg{}
+	txMSGT := &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO15765,
+		DataSize:   6,
+		Data: [4128]byte{0x00, 0X00, 0x07, 0xDF, 0x09, 0x02},
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSGT, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	log.Println("VIN: " + string(rxMSGS.Data[7:24]))
+
+	txMSGT = &passthru.PassThruMsg{
+		ProtocolID: passthru.ISO15765,
+		DataSize:   6,
+		Data: [4128]byte{0x00, 0X00, 0x07, 0xDF, 0x09, 0x04},
+	}
+	if err := pt.PassThruWriteMsgs(channelID, txMSGT, &msg1, 500); err != nil {
+		return fmt.Errorf("PassThruWriteMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err)
+	}
+	if err := pt.PassThruReadMsgs(channelID, rxMSGS, &msg1, 900); err != nil {
+		return fmt.Errorf("PassThruReadMsgs: %w", err) 
+	}
+	log.Println("Calibration: " + string(rxMSGS.Data[7:23]))
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,15 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/google/gousb v1.1.3
 	go.bug.st/serial v1.6.4
-	go.einride.tech/can v0.12.1
-	golang.org/x/sync v0.17.0
+	golang.org/x/sync v0.17.0 // indirect
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.10
 )
 
-require github.com/Microsoft/go-winio v0.6.2
+require (
+	github.com/Microsoft/go-winio v0.6.2
+	go.einride.tech/can v0.16.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -44,3 +46,5 @@ require (
 	github.com/creack/goselect v0.1.2 // indirect
 	golang.org/x/sys v0.34.0
 )
+
+replace go.einride.tech/can => github.com/samuelbrian/can-go v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -36,13 +36,13 @@ github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/samuelbrian/can-go v0.0.2 h1:M2B5j9O97lCGlsUYTWYFBwdhHWvA9HpW+A1wfDukRN4=
+github.com/samuelbrian/can-go v0.0.2/go.mod h1:a1aqkRYR3BBP3u9uJvvZQjn//TtH5MnlMsAzbR9IQvM=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.bug.st/serial v1.6.4 h1:7FmqNPgVp3pu2Jz5PoPtbZ9jJO5gnEnZIvnI1lzve8A=
 go.bug.st/serial v1.6.4/go.mod h1:nofMJxTeNVny/m6+KaafC6vJGj3miwQZ6vW4BZUGJPI=
-go.einride.tech/can v0.12.1 h1:XBpAw6/pbjFJX9cybSXVNyZ4hhpLHjrj9iI58yFI53w=
-go.einride.tech/can v0.12.1/go.mod h1:5n3+AonCfUso6PfjD9l2d0W2LxTFjjHOnHAm+UMS9Ws=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=


### PR DESCRIPTION
* socketcan: fix build, use kernel filtering. It require fork lib for kernel filtering -> means gateway and txloger mod's need update. If It's not fine, I'll get back to the old way.
   ---> replace go.einride.tech/can => github.com/samuelbrian/can-go v0.0.2
* add: j2534 examples introduces cases to reed VIN from dice over kline and t8 over isotp